### PR TITLE
Bug fix for _normalizeLogicle. Parameter override and return parameter functionality for normalize_logicle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 
 This package provides efficient and scalable handling of flow and mass cytometry data analysis. It provides
 
--   the functionality to read in flow data in the fcs file format as [anndata](https://anndata.readthedocs.io/en/latest/) objects
--   flow and mass cytometry specific preprocessing tools
--   access to the entire [scanpy](https://scanpy.readthedocs.io/en/stable/) workflow functionality
--   GPU support through [rapids-singlecell](https://rapids-singlecell.readthedocs.io/)
+- the functionality to read in flow data in the fcs file format as [anndata](https://anndata.readthedocs.io/en/latest/) objects
+- flow and mass cytometry specific preprocessing tools
+- access to the entire [scanpy](https://scanpy.readthedocs.io/en/stable/) workflow functionality
+- GPU support through [rapids-singlecell](https://rapids-singlecell.readthedocs.io/)
 
 ## Getting started
 
 Please refer to the [documentation][link-docs]. In particular, the
 
--   [API documentation][link-api].
+- [API documentation][link-api].
 
 ## Installation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -99,11 +99,11 @@ Specify `vX.X.X` as a tag name and create a release. For more information, see [
 
 Please write documentation for new or changed features and use-cases. This project uses [sphinx][] with the following features:
 
--   the [myst][] extension allows to write documentation in markdown/Markedly Structured Text
--   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
--   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
--   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
--   Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
+- the [myst][] extension allows to write documentation in markdown/Markedly Structured Text
+- [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
+- Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
+- [Sphinx autodoc typehints][], to automatically reference annotated input and output types
+- Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.
@@ -120,10 +120,10 @@ repository.
 
 #### Hints
 
--   If you refer to objects from other packages, please add an entry to `intersphinx_mapping` in `docs/conf.py`. Only
-    if you do so can sphinx automatically create a link to the external documentation.
--   If building the documentation fails because of a missing link that is outside your control, you can add an entry to
-    the `nitpick_ignore` list in `docs/conf.py`
+- If you refer to objects from other packages, please add an entry to `intersphinx_mapping` in `docs/conf.py`. Only
+  if you do so can sphinx automatically create a link to the external documentation.
+- If building the documentation fails because of a missing link that is outside your control, you can add an entry to
+  the `nitpick_ignore` list in `docs/conf.py`
 
 #### Building the docs locally
 

--- a/src/pytometry/tl/_normalization.py
+++ b/src/pytometry/tl/_normalization.py
@@ -587,7 +587,7 @@ def normalize_autologicle(
     q: float = 0.05,
     inplace: bool = True,
     return_params: bool = False,
-    params_override: list[dict] | None = None
+    params_override: list[dict] | None = None,
 ) -> AnnData | list[dict] | None:
     """Autologicle transformation.
 

--- a/src/pytometry/tl/_normalization.py
+++ b/src/pytometry/tl/_normalization.py
@@ -654,8 +654,15 @@ def normalize_autologicle(
         params_list.append(params)
         adata.X[:, channel_idx] = transforms.logicle(adata.X[:, channel_idx], channel_indices=[channel_idx], **params)
     if return_params:
-        return params_list if inplace else adata, params_list
-    return None if inplace else adata
+        if inplace:
+            return params_list
+        else:
+            return adata, params_list
+    else:
+        if inplace:
+            return
+        else:
+            return adata
 
 
 def _logicleTransform(channel: str, adata: AnnData, m: float, q: float):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -128,4 +128,26 @@ def test_autologicle_param_override():
     params_list = [params for _ in range(adata.n_vars)] # list of identical params
     result1 = transforms.logicle(adata.X, channel_indices, **params)
     result2 = normalize_autologicle(adata, inplace=False, params_override=params_list).X
-    numpy.testing.assert_allclose(result1, result2, atol=1e-5)
+    assert (result1 == result2).all()
+
+def test_return_params():
+    path_data = readfcs.datasets.Oetjen18_t1()
+    adata = read_fcs(path_data)
+    # case 1: non-mutative, return params
+    adata2, params_list = normalize_autologicle(adata, inplace=False, return_params=True)
+    assert isinstance(adata2, anndata._core.anndata.AnnData)
+    assert isinstance(params_list, list)
+    assert isinstance(params_list[0], dict)
+    # case 2: non-mutative, don't return params
+    adata2 = normalize_autologicle(adata, inplace=False, return_params=False)
+    assert isinstance(adata2, anndata._core.anndata.AnnData)
+    # case 3: mutative, return params
+    params_list = normalize_autologicle(adata, inplace=True, return_params=True)
+    assert isinstance(params_list, list)
+    assert isinstance(params_list[0], dict)
+    assert (adata.X == adata2.X).all() # check if inplace=True works
+    adata = read_fcs(path_data)
+    # case 4: mutative, don't return params
+    result = normalize_autologicle(adata, inplace=True, return_params=False)
+    assert (adata.X == adata2.X).all() # check if inplace=True works
+    assert result == None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -151,10 +151,5 @@ def test_return_params():
     adata = read_fcs(path_data)
     # case 4: mutative, don't return params
     result = normalize_autologicle(adata, inplace=True, return_params=False)
-<<<<<<< HEAD
     assert (adata.X == adata2.X).all() # check if inplace=True works
     assert result is None
-=======
-    assert (adata.X == adata2.X).all()  # check if inplace=True works
-    assert result == None
->>>>>>> 3422132421cce46544e545bd3de1eb36b2218734

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -150,4 +150,4 @@ def test_return_params():
     # case 4: mutative, don't return params
     result = normalize_autologicle(adata, inplace=True, return_params=False)
     assert (adata.X == adata2.X).all() # check if inplace=True works
-    assert result == None
+    assert result is None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -151,5 +151,5 @@ def test_return_params():
     adata = read_fcs(path_data)
     # case 4: mutative, don't return params
     result = normalize_autologicle(adata, inplace=True, return_params=False)
-    assert (adata.X == adata2.X).all() # check if inplace=True works
+    assert (adata.X == adata2.X).all()  # check if inplace=True works
     assert result is None

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,11 +2,11 @@ import anndata
 import numpy
 import pandas
 import readfcs
+from flowutils import transforms
 
 from pytometry.io import read_fcs
 from pytometry.pp import _dummy_spillover, compensate, create_comp_mat
-from pytometry.tl import normalize_arcsinh, normalize_biexp, normalize_logicle, normalize_autologicle
-from flowutils import transforms
+from pytometry.tl import normalize_arcsinh, normalize_autologicle, normalize_biexp, normalize_logicle
 
 
 # test read function
@@ -115,6 +115,7 @@ def test_normalize_logicle2():
     adata2 = normalize_logicle(adata, inplace=False)
     assert isinstance(adata2, anndata._core.anndata.AnnData)
 
+
 def test_autologicle_param_override():
     path_data = readfcs.datasets.Oetjen18_t1()
     adata = read_fcs(path_data)
@@ -125,10 +126,11 @@ def test_autologicle_param_override():
         "m": 4.5,
         "a": 0,
     }
-    params_list = [params for _ in range(adata.n_vars)] # list of identical params
+    params_list = [params for _ in range(adata.n_vars)]  # list of identical params
     result1 = transforms.logicle(adata.X, channel_indices, **params)
     result2 = normalize_autologicle(adata, inplace=False, params_override=params_list).X
     assert (result1 == result2).all()
+
 
 def test_return_params():
     path_data = readfcs.datasets.Oetjen18_t1()
@@ -145,9 +147,14 @@ def test_return_params():
     params_list = normalize_autologicle(adata, inplace=True, return_params=True)
     assert isinstance(params_list, list)
     assert isinstance(params_list[0], dict)
-    assert (adata.X == adata2.X).all() # check if inplace=True works
+    assert (adata.X == adata2.X).all()  # check if inplace=True works
     adata = read_fcs(path_data)
     # case 4: mutative, don't return params
     result = normalize_autologicle(adata, inplace=True, return_params=False)
+<<<<<<< HEAD
     assert (adata.X == adata2.X).all() # check if inplace=True works
     assert result is None
+=======
+    assert (adata.X == adata2.X).all()  # check if inplace=True works
+    assert result == None
+>>>>>>> 3422132421cce46544e545bd3de1eb36b2218734


### PR DESCRIPTION
- Fixed issue for channels with no negative values

To enable transformation on holdout sets using parameters from a training set, implemented the following: 
- Added option to override parameters within normalize_autologicle
- Added option to return the parameters used by normalize_autologicle